### PR TITLE
  Fix v6 parasail cmake build; drop Windows support

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,3 +1,0 @@
-python setup.py all
-mkdir %PREFIX%\bin
-copy %SRC_DIR%\dist\bin\sortmerna.exe %PREFIX%\bin

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+export CMAKE_GENERATOR=Ninja
 python setup.py all
 mkdir -p $PREFIX/bin
 cp -r $SRC_DIR/dist/bin/sortmerna $PREFIX/bin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,12 +11,9 @@ source:
 
 build:
   number: 0
-  skip: true  # [win]
   # we decided to skip linux-ppc64le due to lack of maintainer interest
   # https://github.com/conda-forge/sortmerna-feedstock/pull/7
   skip: true  # [ppc64le]
-  # Using nocona CPU target to ensure maximum compatibility across x86_64 systems
-  # This prevents illegal instruction errors on systems without newer CPU features
 
 requirements:
   build:
@@ -24,20 +21,19 @@ requirements:
     - {{ stdlib('c') }}
     - {{ compiler('cxx') }}
     - cmake
+    - ninja
     - git
   host:
     - python
     - pyyaml
     - jinja2
     - requests
-    - ninja
   run:
     - python
 
 test:
   commands:
-    - {{ name }} -h  # [not win]
-    - {{ name }}.exe -h  # [win]
+    - {{ name }} -h
 
 about:
   home: http://bioinfo.lifl.fr/RNA/sortmerna


### PR DESCRIPTION
  - Export CMAKE_GENERATOR=Ninja in build.sh so upstream setup.py's parasail_build cmake call (which omits -G) doesn't fall back to Unix Makefiles and fail with missing make/compiler.
  - Move ninja from host to build deps (build script runs in build env).
  - Remove Windows: drop bld.bat, skip selector, and .exe test command.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
